### PR TITLE
Don't expose postgresql port

### DIFF
--- a/pages/backend/deploy.mdx
+++ b/pages/backend/deploy.mdx
@@ -34,8 +34,6 @@ This method provides a straightforward setup with minimal configuration. For mor
              POSTGRES_USER: movie_web_user 
              POSTGRES_DB: movie_web_backend 
              POSTGRES_PASSWORD: YourPasswordHere 
-           ports:
-             - "5432:5432" 
            networks:
              - sudo-flix-network
          sudo-flix:


### PR DESCRIPTION
The backend and postgres containers share a bridge network; they can communicate without having to expose the port to the host. 

[source](https://docs.docker.com/network/drivers/bridge/#:~:text=Containers%20connected%20to%20the%20same%20user,flag.)