### PR TITLE
update netlify proxy deploy steps

### DIFF
--- a/pages/proxy/deploy.mdx
+++ b/pages/proxy/deploy.mdx
@@ -8,20 +8,31 @@ title: 'Deploy'
 
 Netlify has a very generous free plan, so you'll be able to host your proxy for free unless you get hundreds of users.
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/sussy-code/sudo-proxy)
-
 <Steps>
    <Steps.Step>
      Create a GitHub account at https://github.com/signup if you don't have one already.
    </Steps.Step>
 
    <Steps.Step>
-    Click on the `Deploy to Netlify` button above.
+     Fork the [sudo-proxy repository](https://github.com/sussy-code/sudo-proxy) by clicking the `Fork` button in the top right corner. 
+   </Steps.Step>
+
+
+   <Steps.Step>
+    Go to https://app.netlify.com/ and click `Sign Up` in the top right corner.
        - Authorize Netlify to connect with GitHub by clicking the `Connect to GitHub` button.
    </Steps.Step>
 
    <Steps.Step>
-     There should now be a `Save & Deploy` button, click it.
+     Click on the `Add new site` button in the top right corner and select `Import an existing project` from the dropdown.
+   </Steps.Step>
+
+   <Steps.Step>
+     Chose `GitHub` from the list and select the repository you forked. 
+   </Steps.Step>
+
+   <Steps.Step>
+     Name your site and click `Deploy`.
    </Steps.Step>
 
    <Steps.Step>


### PR DESCRIPTION
Pressing the `Deploy to Netlify` button doesn't work because it always has an ownership build error.
This PR changes the steps to import the forked repo which resolves this error manually.